### PR TITLE
feature: omit empty deleted attribute in hooks

### DIFF
--- a/source/hooks.ts
+++ b/source/hooks.ts
@@ -16,7 +16,7 @@ export default function(schema: DeletedSchema, methods?: Methods[] | boolean): v
 			this: Query<unknown, T>
 		) {
 			if (deletedIsNotAlreadyInQuery(this)) {
-				this.where({ deleted: false });
+				this.where({ deleted: { $ne: true, $exists: false } });
 			}
 		});
 	}
@@ -26,7 +26,7 @@ export default function(schema: DeletedSchema, methods?: Methods[] | boolean): v
 			this: Aggregate<unknown>
 		) {
 			if (deletedIsNotAlreadyInAggregation(this)) {
-				this.pipeline().unshift({ $match: { deleted: false } });
+				this.pipeline().unshift({ $match: { deleted: { $ne: true, $exists: false } } });
 			}
 		});
 	}


### PR DESCRIPTION
Hi!
As a developer,
I want to have the possibility to receive documents that have no "deleted" attribute by default as not deleted documents.
Thank you.